### PR TITLE
去除input的id, 直接设置input为display=none,不使用定位方式进行隐藏

### DIFF
--- a/jupload.js
+++ b/jupload.js
@@ -48,13 +48,10 @@
 			that.settings[key] = options[key];
 		}
 
-		that.$el.style.cssText = "position:relative;";
-
 		var input = document.createElement("input");
-		input.id = "__upload_input__";
 		input.type = "file";
 		input.accept = that.settings.accept;
-		input.style.cssText = "position:absolute;left:-10000px;top:-10000px;";
+        	input.style.display = 'none';
 
 		that.$el.appendChild(input);
 


### PR DESCRIPTION
1. 去除input的id, 理由: 首先,下面的代码并没有用到这个id; 其次,之前的id并没有考虑JUpload有多个实例的情况;
2. 直接使用display=none而不使用定位方式进行隐藏, 理由是: 使用定位的方式需要改变父容器的定位方式, 在有些情况下会破坏父容器已有的定位.
